### PR TITLE
Handle optional values when validating

### DIFF
--- a/flask_pydantic_spec/flask_backend.py
+++ b/flask_pydantic_spec/flask_backend.py
@@ -143,12 +143,12 @@ class FlaskBackend:
             request,
             "context",
             Context(
-                query=query.parse_obj(req_query) if query else None,
+                query=query.parse_obj(req_query or {}) if query else None,
                 body=getattr(body, "model").parse_obj(parsed_body)
                 if body and getattr(body, "model")
                 else None,
-                headers=headers.parse_obj(req_headers) if headers else None,
-                cookies=cookies.parse_obj(req_cookies) if cookies else None,
+                headers=headers.parse_obj(req_headers or {}) if headers else None,
+                cookies=cookies.parse_obj(req_cookies or {}) if cookies else None,
             ),
         )
 

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,5 +1,5 @@
 from enum import IntEnum, Enum
-from typing import List
+from typing import List, Optional
 
 from pydantic import BaseModel, root_validator
 
@@ -10,7 +10,7 @@ class Order(IntEnum):
 
 
 class Query(BaseModel):
-    order: Order
+    order: Optional[Order]
 
 
 class JSON(BaseModel):

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -49,7 +49,9 @@ def ping():
 )
 def user_score(name):
     score = [randint(0, request.context.body.limit) for _ in range(5)]
-    score.sort(reverse=request.context.query.order)
+    score.sort(
+        reverse=request.context.query.order if request.context.query.order else False
+    )
     assert request.context.cookies.pub == "abcdefg"
     assert request.cookies["pub"] == "abcdefg"
     return jsonify(name=request.context.body.name, score=score)
@@ -111,6 +113,13 @@ def test_flask_validate(client):
 
     resp = client.post(
         "/api/user/flask?order=0",
+        data=json.dumps(dict(name="flask", limit=10)),
+        content_type="application/json",
+    )
+    assert resp.json["score"] == sorted(resp.json["score"], reverse=False)
+
+    resp = client.post(
+        "/api/user/flask",
         data=json.dumps(dict(name="flask", limit=10)),
         content_type="application/json",
     )


### PR DESCRIPTION
Pydantic expects to be given at least a Dictionary when using `parse_obj`, however they don't enforce this via type hints.

This changes the validation to use an empty dictionary if a value isn't provided.