### PR TITLE
Add ability to handle multiple query params for the same key as a list

### DIFF
--- a/flask_pydantic_spec/utils.py
+++ b/flask_pydantic_spec/utils.py
@@ -3,6 +3,7 @@ import logging
 
 from typing import Callable, Mapping, Any, Tuple, Optional, List, Dict
 
+from werkzeug.datastructures import MultiDict
 from flask import Request as FlaskRequest
 from pydantic import BaseModel
 
@@ -177,3 +178,13 @@ def default_after_handler(
                 "spectree_validation": resp_validation_error.errors(),
             },
         )
+
+
+def parse_multi_dict(input: MultiDict) -> Dict[str, Any]:
+    result = {}
+    for key, value in input.to_dict(flat=False).items():
+        if len(value) == 1:
+            result[key] = value[0]
+        else:
+            result[key] = value
+    return result

--- a/tests/common.py
+++ b/tests/common.py
@@ -13,6 +13,18 @@ class Query(BaseModel):
     order: Optional[Order]
 
 
+class QueryParams(BaseModel):
+    name: Optional[List[str]]
+
+
+class User(BaseModel):
+    name: str
+
+
+class Users(BaseModel):
+    data: List[User]
+
+
 class JSON(BaseModel):
     name: str
     limit: int

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -9,6 +9,7 @@ def test_plugin_spec():
     assert get_paths(api.spec) == [
         "/api/file",
         "/api/group/{name}",
+        "/api/user",
         "/api/user/{name}",
         "/ping",
     ]


### PR DESCRIPTION
This PR adds the ability for a client to make a request with repeats of the same parameter in the query and for us to parse these as a list in the pydantic model.