### PR TITLE
Release 0.1.4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,26 @@
+.. currentmodule:: flask-pydantic-spec
+
+Version 0.1.4
+-------------
+
+Released 2021-04-27
+
+- Added the ability to specify multiple query params with the same name and for these to be interpreted as a list in the pydantic model that is used
+
+Version 0.1.3
+-------------
+
+Released 2020-11-23
+
+- Allowed the validation to handle optional parameters (i.e the body of a request is Optional)
+
+
+Version 0.1.2
+-------------
+
+Released 2020-11-23
+
+- Added type hints and MyPy linting throughout the code base.
+- Removed references to Spectree
+- Removed any other backend other than the Flask one.
+- Major refactoring and cleanup

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(here, 'requirements/production.txt'), encoding='utf-8') as f
 
 setup(
     name='flask_pydantic_spec',
-    version='0.1.3',
+    version='0.1.4',
     author='Chris Gearing, Simon Hayward, Rob Young, Donald Fleming, Saurabh Jha',
     author_email='chris.gearing@turntown.digital',
     description=('generate OpenAPI document and validate request&response '


### PR DESCRIPTION
This PR is getting `flask-pydantic-spec` ready for release 0.1.4

It adds a `CHANGES.rst` file, which is where we should be putting release changes (stolen from Flask).