### PR TITLE
Fix/add check for duplicate types

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Check the [examples](/examples) folder.
 ### Step by Step
 
 1. Define your data structure used in (query, json, headers, cookies, resp) with `pydantic.BaseModel`
-2. create `flask_pydantic_spec.Validator` instance with the web framework name you are using, like `api = Validator('flask')`
+2. create `flask_pydantic_spec.FlaskPydanticSpec` instance with the web framework name you are using, like `api = FlaskPydanticSpec('flask')`
 3. `api.validate` decorate the route with
    * `query`
    * `body`
@@ -147,7 +147,3 @@ if __name__ == "__main__":
 
 The HTTP headers' keys in Flask are capitalized.
 You can use [`pydantic.root_validators(pre=True)`](https://pydantic-docs.helpmanual.io/usage/validators/#root-validators) to change all the keys into lower cases or upper cases.
-
-> ValidationError: value is not a valid list for query
-
-Since there is no standard for HTTP query with multiple values, it's hard to find the way to handle this for different web frameworks. So I suggest not to use list type in query until I find a suitable way to fix it.

--- a/flask_pydantic_spec/spec.py
+++ b/flask_pydantic_spec/spec.py
@@ -121,14 +121,14 @@ class FlaskPydanticSpec:
         - add tags to this API route
 
         :param query: `pydantic.BaseModel`, query in uri like `?name=value`
-        :param body: `spectree.Request`, Request body
+        :param body: `flask_pydantic_spec.Request`, Request body
         :param headers: `pydantic.BaseModel`, if you have specific headers
         :param cookies: `pydantic.BaseModel`, if you have cookies for this route
-        :param resp: `spectree.Response`
+        :param resp: `flask_pydantic_spec.Response`
         :param tags: a tuple of tags string
         :param deprecated: You can mark specific operations as deprecated to indicate that they should be transitioned out of usage
-        :param before: :meth:`spectree.utils.default_before_handler` for specific endpoint
-        :param after: :meth:`spectree.utils.default_after_handler` for specific endpoint
+        :param before: :meth:`flask_pydantic_spec.utils.default_before_handler` for specific endpoint
+        :param after: :meth:`flask_pydantic_spec.utils.default_after_handler` for specific endpoint
         """
 
         def decorate_validation(func: Callable) -> Callable:
@@ -306,6 +306,9 @@ class FlaskPydanticSpec:
         for model, schema in self.models.items():
             if model not in definitions.keys():
                 definitions[model] = schema
+            else:
+                if definitions[model] != schema:
+                    raise ValueError(f"Duplicate schema found for type - {model}")
             if "definitions" in schema:
                 for key, value in schema["definitions"].items():
                     definitions[key] = self._get_open_api_schema(value)

--- a/flask_pydantic_spec/utils.py
+++ b/flask_pydantic_spec/utils.py
@@ -4,7 +4,6 @@ import logging
 from typing import Callable, Mapping, Any, Tuple, Optional, List, Dict
 
 from werkzeug.datastructures import MultiDict
-from flask import Request as FlaskRequest
 from pydantic import BaseModel
 
 from .types import Response, RequestBase, Request


### PR DESCRIPTION
This PR does a couple of things.

1. Add a check for duplicate model names with different schemas.  This fixes an issue where different models with the same name can conflict, resulting in only a single model being exposed.
2. Tidy up the readme slightly.