### PR TITLE
Do model path conversion immediately after collecting

### DIFF
--- a/flask_pydantic_spec/flask_backend.py
+++ b/flask_pydantic_spec/flask_backend.py
@@ -1,6 +1,6 @@
 import logging
 
-from typing import Optional, Mapping, Callable, Any, Tuple, List, Type, Union
+from typing import Optional, Mapping, Callable, Any, Tuple, List, Type, Iterable, Dict
 from dataclasses import dataclass
 
 from pydantic import ValidationError, BaseModel
@@ -13,11 +13,11 @@ from flask import (
     Flask,
     Response as FlaskResponse,
 )
-from werkzeug.datastructures import EnvironHeaders
+from werkzeug.datastructures import Headers
 
 from .config import Config
 from .page import PAGES
-from .types import ResponseBase, RequestBase, Request
+from .types import ResponseBase, RequestBase
 from .utils import parse_multi_dict
 
 
@@ -60,16 +60,17 @@ class FlaskBackend:
         subs = []
         parameters = []
 
-        for converter, arguments, variable in parse_rule(str(route)):  # type: ignore
+        for converter, arguments, variable in parse_rule(str(route)):
             if converter is None:
                 subs.append(variable)
                 continue
             subs.append(f"{{{variable}}}")
 
-            args, kwargs = [], {}
+            args: Iterable[Any] = []
+            kwargs: Dict[str, Any] = {}
 
             if arguments:
-                args, kwargs = parse_converter_args(arguments)  # type: ignore
+                args, kwargs = parse_converter_args(arguments)
 
             schema = None
             if converter == "any":
@@ -142,7 +143,7 @@ class FlaskBackend:
             parsed_body = request.get_json() or {}
         else:
             parsed_body = request.get_data() or {}
-        req_headers: Optional[EnvironHeaders] = request.headers or None
+        req_headers: Optional[Headers] = request.headers or None
         req_cookies: Optional[Mapping[str, str]] = request.cookies or None
         setattr(
             request,

--- a/flask_pydantic_spec/spec.py
+++ b/flask_pydantic_spec/spec.py
@@ -296,7 +296,9 @@ class FlaskPydanticSpec:
                 result[key] = self._validate_property(value)
             else:
                 result[key] = value
-        return result
+        return cast(
+            Mapping[str, Any], nested_alter(result, "$ref", _move_schema_reference)
+        )
 
     def _get_model_definitions(self) -> Dict[str, Any]:
         """
@@ -311,7 +313,7 @@ class FlaskPydanticSpec:
                     definitions[key] = self._get_open_api_schema(value)
                 del schema["definitions"]
 
-        return cast(Dict, nested_alter(definitions, "$ref", _move_schema_reference))
+        return definitions
 
     def _parse_request_body(self, request_body: Mapping[str, Any]) -> Mapping[str, Any]:
         content_types = list(request_body["content"].keys())

--- a/flask_pydantic_spec/utils.py
+++ b/flask_pydantic_spec/utils.py
@@ -54,42 +54,45 @@ def parse_params(
     """
     if hasattr(func, "query"):
         model_name = getattr(func, "query").__name__
-        query = models[model_name]
-        for name, schema in query["properties"].items():
-            params.append(
-                {
-                    "name": name,
-                    "in": "query",
-                    "schema": schema,
-                    "required": name in query.get("required", []),
-                }
-            )
+        query = models.get(model_name)
+        if query is not None:
+            for name, schema in query["properties"].items():
+                params.append(
+                    {
+                        "name": name,
+                        "in": "query",
+                        "schema": schema,
+                        "required": name in query.get("required", []),
+                    }
+                )
 
     if hasattr(func, "headers"):
         model_name = getattr(func, "headers").__name__
-        headers = models[model_name]
-        for name, schema in headers["properties"].items():
-            params.append(
-                {
-                    "name": name,
-                    "in": "header",
-                    "schema": schema,
-                    "required": name in headers.get("required", []),
-                }
-            )
+        headers = models.get(model_name)
+        if headers is not None:
+            for name, schema in headers["properties"].items():
+                params.append(
+                    {
+                        "name": name,
+                        "in": "header",
+                        "schema": schema,
+                        "required": name in headers.get("required", []),
+                    }
+                )
 
     if hasattr(func, "cookies"):
         model_name = getattr(func, "cookies").__name__
-        cookies = models[model_name]
-        for name, schema in cookies["properties"].items():
-            params.append(
-                {
-                    "name": name,
-                    "in": "cookie",
-                    "schema": schema,
-                    "required": name in cookies.get("required", []),
-                }
-            )
+        cookies = models.get(model_name)
+        if cookies is not None:
+            for name, schema in cookies["properties"].items():
+                params.append(
+                    {
+                        "name": name,
+                        "in": "cookie",
+                        "schema": schema,
+                        "required": name in cookies.get("required", []),
+                    }
+                )
 
     return params
 

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1,3 +1,6 @@
+from enum import Enum
+from typing import Optional
+
 import pytest
 from flask import Flask
 from typing import List
@@ -17,6 +20,16 @@ class ExampleModel(BaseModel):
     name: str = Field(strip_whitespace=True)
     age: int
     height: StrictFloat
+
+
+class TypeEnum(str, Enum):
+    foo = "foo"
+    bar = "bar"
+
+
+class ExampleQuery(BaseModel):
+    query: str
+    type: Optional[TypeEnum]
 
 
 class ExampleNestedList(BaseModel):
@@ -105,6 +118,11 @@ def create_app():
     def lone_post():
         pass
 
+    @app.route("/query", methods=["GET"])
+    @api.validate(query=ExampleQuery)
+    def get_query():
+        pass
+
     @app.route("/file")
     @api.validate(resp=FileResponse())
     def get_file():
@@ -131,11 +149,23 @@ def create_app():
 def test_spec_bypass_mode():
     app = create_app()
     api.register(app)
-    assert get_paths(api.spec) == ["/file", "/foo", "/lone", "/multipart-file"]
+    assert get_paths(api.spec) == [
+        "/file",
+        "/foo",
+        "/lone",
+        "/multipart-file",
+        "/query",
+    ]
 
     app = create_app()
     api_customize_backend.register(app)
-    assert get_paths(api.spec) == ["/file", "/foo", "/lone", "/multipart-file"]
+    assert get_paths(api.spec) == [
+        "/file",
+        "/foo",
+        "/lone",
+        "/multipart-file",
+        "/query",
+    ]
 
     app = create_app()
     api_greedy.register(app)
@@ -145,6 +175,7 @@ def test_spec_bypass_mode():
         "/foo",
         "/lone",
         "/multipart-file",
+        "/query",
     ]
 
     app = create_app()


### PR DESCRIPTION
We ran into an issue where a complex type (enum) was added to a query parameter, which resulted in the schema not getting the same change from `"$ref": "/definitions/{model_name}"` -> `"$ref": "/components/schemas/{model_name}"`

This PR fixes that issue, and fixes a bug in the parameter parsing for greedy APIs where the model isn't actually attached to the instance of the FlaskPyanticSpec class.

I wonder if we should remove the different types of collection and just have a single version that only collects routes/models it is decorated on?