### PR TITLE
Change the behavior of request header validation

### DIFF
--- a/flask_pydantic_spec/flask_backend.py
+++ b/flask_pydantic_spec/flask_backend.py
@@ -139,7 +139,7 @@ class FlaskBackend:
             req_query = parse_multi_dict(raw_query)
         else:
             req_query = {}
-        if request.content_type == "application/json":
+        if "application/json" in request.content_type:
             parsed_body = request.get_json() or {}
         else:
             parsed_body = request.get_data() or {}


### PR DESCRIPTION
We had a problem when we received a header Content-Type with the text `application/json;charset=utf-8` from a request. Currently, the validation checks if the text of Content-Type is exactly application/json
This fix checks if the `application/json` IS IN the request header `Content-Type`, removing the strict verification