### PR TITLE
Relax pip dependencies

### DIFF
--- a/.github/workflows/test-static-analysis.yml
+++ b/.github/workflows/test-static-analysis.yml
@@ -28,12 +28,9 @@ jobs:
           pip install -r requirements/development.txt
       - name: Lint with flake8
         run: |
-          pip install flake8
           make style
       - name: Test with pytest
         run: |
-          pip install pytest
-          pip install flask
           make test
       - name: Check formatting
         run: |

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,7 +1,8 @@
 -r production.txt
-openapi-spec-validator==0.2.9
-pytest==6.0.1
-flask==1.1.2
-requests==2.24.0
-black==20.8b1
-mypy==0.790
+openapi-spec-validator >=0.2.9, <0.3
+pytest >=6.0.1, <7
+flake8 >=4.0.1, <5
+flask >=2.0.2, <3
+requests >=2.24.0, <3
+black >=20.8b1
+mypy==0.812

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,3 +1,3 @@
-pydantic>=1.2
-inflection==0.5.0
-nested-lookup==0.2.21
+pydantic >=1.2,<2
+inflection >=0.5.0,<1
+nested-lookup >=0.2.21,<1


### PR DESCRIPTION
Fixing the dependencies to specific versions forces downstream dependency resolution to use that specific version.

I've not bumped mypy to the very latest version as it started raising errors.