### PR TITLE
Validate content type contains application json

### DIFF
--- a/flask_pydantic_spec/flask_backend.py
+++ b/flask_pydantic_spec/flask_backend.py
@@ -139,7 +139,7 @@ class FlaskBackend:
             req_query = parse_multi_dict(raw_query)
         else:
             req_query = {}
-        if request.content_type == "application/json":
+        if request.content_type and "application/json" in request.content_type:
             parsed_body = request.get_json() or {}
         else:
             parsed_body = request.get_data() or {}


### PR DESCRIPTION
As requested in #18, this PR just checks the content type has `application/json` in it, rather than matching it exactly.