### PR TITLE
Date in pydantic model failes validation

### DIFF
--- a/flask_pydantic_spec/flask_backend.py
+++ b/flask_pydantic_spec/flask_backend.py
@@ -190,7 +190,12 @@ class FlaskBackend:
             model = resp.find_model(response.status_code)
             if model:
                 try:
-                    model.validate(response.get_json())
+                    # to allow using pydantic json method in views
+                    # validation is achieved by the model itself through parse_raw
+                    model.parse_raw(response.data)
+                    # jsonify not beeing used in favor of pydantic json method the mimetype has to be forced
+                    # this is harmless when using jsonify. validating pydantic implies json.
+                    response.mimetype = 'application/json'
                 except ValidationError as err:
                     resp_validation_error = err
                     response = make_response(

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,3 +1,4 @@
+from datetime import date
 from enum import IntEnum, Enum
 from typing import List, Optional
 
@@ -66,3 +67,7 @@ def get_paths(spec):
 
     paths.sort()
     return paths
+
+
+class HistoryDate(BaseModel):
+    date: date

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -7,6 +7,9 @@ def test_plugin_spec():
     assert api.spec["tags"] == [{"name": tag} for tag in ("test", "health", "api")]
 
     assert get_paths(api.spec) == [
+        "/api/date_cumbersome",
+        "/api/date_direct",
+        "/api/date_naive_not_working",
         "/api/file",
         "/api/group/{name}",
         "/api/user",


### PR DESCRIPTION
- pydantic model is not json serializable through Flask jsonify
- but it's possible to chain pydnatic json -> json loads -> jsonify
- proposition: allow views to return pydantic json directly

fixes #23