### PR TITLE
Fix - Allow user to add extra parameters to multipart/form-data requests

### DIFF
--- a/flask_pydantic_spec/flask_backend.py
+++ b/flask_pydantic_spec/flask_backend.py
@@ -141,6 +141,8 @@ class FlaskBackend:
             req_query = {}
         if request.content_type and "application/json" in request.content_type:
             parsed_body = request.get_json() or {}
+        elif request.content_type and "multipart/form-data" in request.content_type:
+            parsed_body = request.form or {}
         else:
             parsed_body = request.get_data() or {}
         req_headers: Optional[Headers] = request.headers or None

--- a/flask_pydantic_spec/types.py
+++ b/flask_pydantic_spec/types.py
@@ -177,12 +177,12 @@ class MultipartFormRequest(RequestBase):
     def __init__(
         self,
         model: Optional[Type[BaseModel]] = None,
-        file_name: str = "fileName",
+        file_key: str = "file",
         encoding: str = "binary",
     ):
         self.content_type = "multipart/form-data"
         self.model = model
-        self.file_name = file_name
+        self.file_key = file_key
         self.encoding = encoding
 
     def has_model(self) -> bool:
@@ -202,7 +202,7 @@ class MultipartFormRequest(RequestBase):
                         "type": "object",
                         "properties": {
                             **additional_properties,
-                            self.file_name: {
+                            self.file_key: {
                                 "type": "string",
                                 "format": self.encoding,
                             },

--- a/flask_pydantic_spec/utils.py
+++ b/flask_pydantic_spec/utils.py
@@ -33,7 +33,7 @@ def parse_request(func: Callable) -> Mapping[str, Any]:
     Generate spec from body parameter on the view function validation decorator
     """
     if hasattr(func, "body"):
-        request_body = getattr(func, "body", None)
+        request_body = getattr(func, "body")
         if isinstance(request_body, RequestBase):
             result: Mapping[str, Any] = request_body.generate_spec()
         elif issubclass(request_body, BaseModel):
@@ -107,7 +107,9 @@ def parse_resp(func: Callable, code: int) -> Mapping[str, Mapping[str, Any]]:
     """
     responses: Dict[str, Any] = {}
     if hasattr(func, "resp"):
-        responses = getattr(func, "resp", {}).generate_spec()
+        response = getattr(func, "resp")
+        if response:
+            responses = response.generate_spec()
 
     if str(code) not in responses and has_model(func):
         responses[str(code)] = {"description": "Validation Error"}

--- a/tests/common.py
+++ b/tests/common.py
@@ -58,6 +58,10 @@ class DemoModel(BaseModel):
     name: str
 
 
+class FileName(BaseModel):
+    file_name: str
+
+
 def get_paths(spec):
     paths = []
     for path in spec["paths"]:

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -84,7 +84,7 @@ def test_file_request_spec():
 
 
 def test_multipart_form_spec():
-    form = MultipartFormRequest(DemoModel, "file")
+    form = MultipartFormRequest(DemoModel, "fileName")
     spec = form.generate_spec()
     assert spec["content"] == {
         "multipart/form-data": {
@@ -97,7 +97,7 @@ def test_multipart_form_spec():
                     },
                     "limit": {"type": "integer", "title": "Limit"},
                     "name": {"type": "string", "title": "Name"},
-                    "file": {"type": "string", "format": "binary"},
+                    "fileName": {"type": "string", "format": "binary"},
                 },
             }
         }
@@ -112,7 +112,7 @@ def test_multipart_form_no_model():
             "schema": {
                 "type": "object",
                 "properties": {
-                    "fileName": {"type": "string", "format": "binary"},
+                    "file": {"type": "string", "format": "binary"},
                 },
             }
         }


### PR DESCRIPTION
This PR fixes the multipart/form-data functionality in `flask_pydantic_spec` to allow us to extend the body with extra parameters.

In OpenAPI, it is not possible to provide a spec that allows the user to choose the key that the file data lives under.  As such, the file name will be static.

This PR fixes the validation to allow us to successfully instantiate a pydantic object from the form data if provided, validating it as per usual.

I would suggest this should be a major version jump as I renamed the `file_name` attribute on `MultipartFormRequest` as it's currently unclear the purpose of the attribute.