### PR TITLE
Drop python 3.6 support and expand to 3.9, 3.10, 3.11

### DIFF
--- a/.github/workflows/test-static-analysis.yml
+++ b/.github/workflows/test-static-analysis.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest]
 
     steps:

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,8 +1,9 @@
 -r production.txt
-openapi-spec-validator >=0.2.9, <0.3
-pytest >=6.0.1, <7
-flake8 >=4.0.1, <5
-flask >=2.0.2, <3
-requests >=2.24.0, <3
-black >=20.8b1
-mypy==0.812
+openapi-spec-validator>=0.2.9, <0.3
+pytest>=6.0.1, <7
+flake8>=4.0.1, <5
+flask>=2.0.2, <3
+werkzeug==2.1.2
+requests>=2.24.0, <3
+black>=20.8b1
+mypy==0.971

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,11 @@ setup(
     package_data={},
     classifiers=[
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Operating System :: OS Independent",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],


### PR DESCRIPTION
Python 3.6 is EOL and no longer supported.

We are also using Python 3.10 and 3.9 internally, so expanding support for these.