### PR TITLE
Chore/remove nested alter dependency

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,7 +1,7 @@
 # This workflows will upload a Python Package using Twine when a release is created
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
-name: Upload Python Package to Test PyPi
+name: Upload Python Package to PyPi
 
 on:
   release:

--- a/.github/workflows/test-static-analysis.yml
+++ b/.github/workflows/test-static-analysis.yml
@@ -34,6 +34,5 @@ jobs:
           make test
       - name: Check formatting
         run: |
-          pip install -r requirements/development.txt
           black --check tests flask_pydantic_spec
           mypy flask_pydantic_spec

--- a/flask_pydantic_spec/flask_backend.py
+++ b/flask_pydantic_spec/flask_backend.py
@@ -40,10 +40,7 @@ class FlaskBackend:
 
     def find_routes(self) -> Any:
         for rule in self.app.url_map.iter_rules():
-            if any(
-                str(rule).startswith(path)
-                for path in (f"/{self.config.PATH}", "/static")
-            ):
+            if any(str(rule).startswith(path) for path in (f"/{self.config.PATH}", "/static")):
                 continue
             yield rule
 
@@ -58,7 +55,6 @@ class FlaskBackend:
             yield method, func
 
     def parse_path(self, route: Rule) -> Tuple[str, List[Any]]:
-
         subs = []
         parameters = []
 
@@ -143,9 +139,7 @@ class FlaskBackend:
             req_query = {}
         if request.content_type and "application/json" in request.content_type:
             if request.content_encoding and "gzip" in request.content_encoding:
-                raw_body = gzip.decompress(request.stream.read()).decode(
-                    encoding="utf-8"
-                )
+                raw_body = gzip.decompress(request.stream.read()).decode(encoding="utf-8")
                 parsed_body = json.loads(raw_body)
             else:
                 parsed_body = request.get_json() or {}
@@ -186,9 +180,7 @@ class FlaskBackend:
             self.request_validation(request, query, body, headers, cookies)
         except ValidationError as err:
             req_validation_error = err
-            response = make_response(
-                jsonify(err.errors()), self.config.VALIDATION_ERROR_CODE
-            )
+            response = make_response(jsonify(err.errors()), self.config.VALIDATION_ERROR_CODE)
 
         before(request, response, req_validation_error, None)
         if req_validation_error:
@@ -203,9 +195,7 @@ class FlaskBackend:
                     model.validate(response.get_json())
                 except ValidationError as err:
                     resp_validation_error = err
-                    response = make_response(
-                        jsonify({"message": "response validation error"}), 500
-                    )
+                    response = make_response(jsonify({"message": "response validation error"}), 500)
 
         after(request, response, resp_validation_error, None)
 

--- a/flask_pydantic_spec/spec.py
+++ b/flask_pydantic_spec/spec.py
@@ -138,7 +138,8 @@ class FlaskPydanticSpec:
         :param cookies: `pydantic.BaseModel`, if you have cookies for this route
         :param resp: `spectree.Response`
         :param tags: a tuple of tags string
-        :param deprecated: You can mark specific operations as deprecated to indicate that they should be transitioned out of usage
+        :param deprecated: You can mark specific operations as deprecated to indicate that they
+                    should be transitioned out of usage
         :param before: :meth:`spectree.utils.default_before_handler` for specific endpoint
         :param after: :meth:`spectree.utils.default_after_handler` for specific endpoint
         """

--- a/flask_pydantic_spec/spec.py
+++ b/flask_pydantic_spec/spec.py
@@ -29,7 +29,7 @@ def _move_schema_reference(reference: str) -> str:
 
 def _nested_update_references(
     input: Union[Dict[str, Any], List[Dict[str, Any]], str]
-) -> Union[Dict[str, Any], List[Dict[str, Any]], str]:
+) -> Union[Dict[str, Any], List[Any], str]:
     if isinstance(input, str):
         return _move_schema_reference(input)
     elif isinstance(input, Dict):

--- a/flask_pydantic_spec/spec.py
+++ b/flask_pydantic_spec/spec.py
@@ -172,18 +172,14 @@ class FlaskPydanticSpec:
                     else:
                         _model = model
                     if _model:
-                        self.models[_model.__name__] = self._get_open_api_schema(
-                            _model.schema()
-                        )
+                        self.models[_model.__name__] = self._get_open_api_schema(_model.schema())
                     setattr(validation, name, model)
 
             if resp:
                 for model in resp.models:
                     if model:
                         assert not isinstance(model, RequestBase)
-                        self.models[model.__name__] = self._get_open_api_schema(
-                            model.schema()
-                        )
+                        self.models[model.__name__] = self._get_open_api_schema(model.schema())
                 setattr(validation, "resp", resp)
 
             if tags:
@@ -232,9 +228,9 @@ class FlaskPydanticSpec:
 
                 request_body = parse_request(func)
                 if request_body:
-                    routes[path][method.lower()][
-                        "requestBody"
-                    ] = self._parse_request_body(request_body)
+                    routes[path][method.lower()]["requestBody"] = self._parse_request_body(
+                        request_body
+                    )
 
         spec = {
             "openapi": self.config.OPENAPI_VERSION,
@@ -346,8 +342,6 @@ class FlaskPydanticSpec:
         schema = request_body["content"][content_type]["schema"]
         if "$ref" not in schema.keys():
             # handle inline schema definitions
-            return {
-                "content": {content_type: {"schema": self._get_open_api_schema(schema)}}
-            }
+            return {"content": {content_type: {"schema": self._get_open_api_schema(schema)}}}
         else:
             return request_body

--- a/flask_pydantic_spec/spec.py
+++ b/flask_pydantic_spec/spec.py
@@ -294,7 +294,7 @@ class FlaskPydanticSpec:
         for key, value in property.items():
             for prop, val in value.items():
                 if prop in allowed_fields:
-                    result[key][prop] = val
+                    result[key][prop] = _nested_update_references(val)
 
         return result
 
@@ -304,11 +304,11 @@ class FlaskPydanticSpec:
         """
         result = {}
         for key, value in schema.items():
-            if key == "properties":
-                result[key] = self._validate_property(value)
-
             if isinstance(value, (List, Dict)):
                 result[key] = _nested_update_references(value)
+
+            if key == "properties":
+                result[key] = self._validate_property(value)
             else:
                 result[key] = value
 
@@ -322,6 +322,11 @@ class FlaskPydanticSpec:
         for model, schema in self.models.items():
             if model not in definitions.keys():
                 definitions[model] = schema
+
+            if "items" in schema:
+                definitions[model]["items"] = _nested_update_references(schema["items"])
+                del schema["items"]
+
             if "definitions" in schema:
                 for key, value in schema["definitions"].items():
                     definitions[key] = self._get_open_api_schema(value)

--- a/flask_pydantic_spec/types.py
+++ b/flask_pydantic_spec/types.py
@@ -10,17 +10,17 @@ class ResponseBase:
     """
 
     def has_model(self) -> bool:
-        raise NotImplemented
+        raise NotImplementedError
 
     def find_model(self, code: int) -> Optional[Type[BaseModel]]:
-        raise NotImplemented
+        raise NotImplementedError
 
     @property
     def models(self) -> Iterable[Type[BaseModel]]:
-        raise NotImplemented
+        raise NotImplementedError
 
     def generate_spec(self) -> Mapping[str, Any]:
-        raise NotImplemented
+        raise NotImplementedError
 
 
 class Response(ResponseBase):
@@ -131,10 +131,10 @@ class FileResponse(ResponseBase):
 
 class RequestBase:
     def has_model(self) -> bool:
-        raise NotImplemented
+        raise NotImplementedError
 
     def generate_spec(self) -> Mapping[str, Any]:
-        raise NotImplemented
+        raise NotImplementedError
 
 
 class Request(RequestBase):

--- a/flask_pydantic_spec/types.py
+++ b/flask_pydantic_spec/types.py
@@ -33,7 +33,6 @@ class Response(ResponseBase):
     """
 
     def __init__(self, *args: Any, **kwargs: Any):
-
         self.validate = True
         self.codes = []
         for item in args:
@@ -117,11 +116,7 @@ class FileResponse(ResponseBase):
         responses = {
             "200": {
                 "description": DEFAULT_CODE_DESC["HTTP_200"],
-                "content": {
-                    self.content_type: {
-                        "schema": {"type": "string", "format": "binary"}
-                    }
-                },
+                "content": {self.content_type: {"schema": {"type": "string", "format": "binary"}}},
             },
             "404": {"description": DEFAULT_CODE_DESC["HTTP_404"]},
         }
@@ -155,9 +150,7 @@ class Request(RequestBase):
         if self.content_type == "application/octet-stream":
             return {
                 "content": {
-                    self.content_type: {
-                        "schema": {"type": "string", "format": self.encoding}
-                    }
+                    self.content_type: {"schema": {"type": "string", "format": self.encoding}}
                 }
             }
         else:
@@ -165,9 +158,7 @@ class Request(RequestBase):
             return {
                 "content": {
                     self.content_type: {
-                        "schema": {
-                            "$ref": f"#/components/schemas/{self.model.__name__}"
-                        }
+                        "schema": {"$ref": f"#/components/schemas/{self.model.__name__}"}
                     }
                 }
             }

--- a/flask_pydantic_spec/utils.py
+++ b/flask_pydantic_spec/utils.py
@@ -232,7 +232,8 @@ def parse_rule(rule: Rule) -> Iterable[Tuple[Optional[str], Optional[str], str]]
     Parse a rule and return it as generator. Each iteration yields tuples in the form
     ``(converter, arguments, variable)``.
     If the converter is `None` it's a static url part, otherwise it's a dynamic one.
-    Note: This originally lived in werkzeug.routing.parse_rule until it was removed in werkzeug 2.2.0.
+    Note: This originally lived in werkzeug.routing.parse_rule until it was
+    removed in werkzeug 2.2.0.
     TODO - cgearing - do we really need this?
     """
     rule_str = str(rule)

--- a/flask_pydantic_spec/utils.py
+++ b/flask_pydantic_spec/utils.py
@@ -12,12 +12,10 @@ from typing import (
     Optional,
     List,
     Dict,
-    Generator,
     Iterable,
 )
 
 from werkzeug.datastructures import MultiDict
-from flask import Request as FlaskRequest
 from pydantic import BaseModel
 from werkzeug.routing import Rule
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+
+[tool.black]
+line-length = 100
+target-version = ['py38', 'py39', 'py310']
+
+[tool.mypy]
+ignore_missing_imports = true
+disallow_any_generics = false
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_untyped_decorators = true
+disallow_subclassing_any = true
+no_implicit_optional = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+warn_return_any = true

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -1,3 +1,2 @@
 pydantic >=1.2,<2
 inflection >=0.5.0,<1
-nested-lookup >=0.2.21,<1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-ignore = D203
+extend-ignore = D203, E203
 exclude =
     .git,
     __pycache__,

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,15 +11,3 @@ exclude =
 max-line-length = 100
 max-complexity = 15
 
-[mypy]
-ignore_missing_imports = True
-disallow_any_generics = False
-disallow_untyped_calls = True
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-disallow_untyped_decorators = True
-disallow_subclassing_any = True
-no_implicit_optional = True
-warn_redundant_casts = True
-warn_unused_ignores = True
-warn_return_any = True

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -36,9 +36,7 @@ def api_after_handler(req, resp, err, _):
     resp.headers["X-API"] = "OK"
 
 
-api = FlaskPydanticSpec(
-    "flask", before=before_handler, after=after_handler, title="Test API"
-)
+api = FlaskPydanticSpec("flask", before=before_handler, after=after_handler, title="Test API")
 app = Flask(__name__)
 
 
@@ -62,9 +60,7 @@ def get_users():
         {
             "data": [
                 {"name": name}
-                for name in sorted(
-                    set(allowed_names).intersection(set(query_params.name))
-                )
+                for name in sorted(set(allowed_names).intersection(set(query_params.name)))
             ]
         }
     )
@@ -81,27 +77,21 @@ def get_users():
 )
 def user_score(name):
     score = [randint(0, request.context.body.limit) for _ in range(5)]
-    score.sort(
-        reverse=request.context.query.order if request.context.query.order else False
-    )
+    score.sort(reverse=request.context.query.order if request.context.query.order else False)
     assert request.context.cookies.pub == "abcdefg"
     assert request.cookies["pub"] == "abcdefg"
     return jsonify(name=request.context.body.name, score=score)
 
 
 @app.route("/api/group/<name>", methods=["GET"])
-@api.validate(
-    resp=Response(HTTP_200=Resp, HTTP_401=None, validate=False), tags=["api", "test"]
-)
+@api.validate(resp=Response(HTTP_200=Resp, HTTP_401=None, validate=False), tags=["api", "test"])
 def group_score(name):
     score = ["a", "b", "c", "d", "e"]
     return jsonify(name=name, score=score)
 
 
 @app.route("/api/file", methods=["POST"])
-@api.validate(
-    body=MultipartFormRequest(model=FileName), resp=Response(HTTP_200=DemoModel)
-)
+@api.validate(body=MultipartFormRequest(model=FileName), resp=Response(HTTP_200=DemoModel))
 def upload_file():
     files = request.files
     body = request.context.body
@@ -170,9 +160,7 @@ def test_sending_file(client):
         data={
             "file": file,
             "file_name": "another_test.jpg",
-            "data": json.dumps(
-                {"type": "foo", "created_at": str(datetime.now().date())}
-            ),
+            "data": json.dumps({"type": "foo", "created_at": str(datetime.now().date())}),
         },
         content_type="multipart/form-data",
     )
@@ -261,6 +249,4 @@ def test_flask_post_gzip_failure(client):
         },
     )
     assert resp.status_code == 400
-    assert resp.json == [
-        {"loc": ["limit"], "msg": "field required", "type": "value_error.missing"}
-    ]
+    assert resp.json == [{"loc": ["limit"], "msg": "field required", "type": "value_error.missing"}]

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -44,8 +44,7 @@ def test_response_spec():
     assert spec["200"]["description"] == DEFAULT_CODE_DESC["HTTP_200"]
     assert spec["201"]["description"] == DEFAULT_CODE_DESC["HTTP_201"]
     assert (
-        spec["201"]["content"]["application/json"]["schema"]["$ref"].split("/")[-1]
-        == "DemoModel"
+        spec["201"]["content"]["application/json"]["schema"]["$ref"].split("/")[-1] == "DemoModel"
     )
 
     assert spec.get(200) is None
@@ -58,13 +57,8 @@ def test_file_response_spec():
     assert spec["200"]["description"] == DEFAULT_CODE_DESC["HTTP_200"]
     assert spec["404"]["description"] == DEFAULT_CODE_DESC["HTTP_404"]
 
-    assert (
-        spec["200"]["content"]["application/octet-stream"]["schema"]["format"]
-        == "binary"
-    )
-    assert (
-        spec["200"]["content"]["application/octet-stream"]["schema"]["type"] == "string"
-    )
+    assert spec["200"]["content"]["application/octet-stream"]["schema"]["format"] == "binary"
+    assert spec["200"]["content"]["application/octet-stream"]["schema"]["type"] == "string"
 
     pdf_resp = FileResponse("application/pdf")
     pdf_spec = pdf_resp.generate_spec()

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -198,7 +198,7 @@ def test_valid_openapi_spec():
     app = create_app()
     api.register(app)
     spec = api.spec
-    breakpoint()
+
     validate_v3_spec(spec)
 
 
@@ -221,18 +221,27 @@ def test_openapi_deprecated():
 
 
 @pytest.mark.parametrize(
-    "input,output", [
+    "input,output",
+    [
         ("a string", "a string"),
         ({"$ref": "#/definitions/Foo"}, {"$ref": "#/components/schemas/Foo"}),
-        ({"Foo": {"$ref": "#/definitions/Foo"}}, {"Foo": {"$ref": "#/components/schemas/Foo"}}),
-        ({"Foo": {"Bar": {"$ref": "#/definitions/Foo"}}}, {"Foo": {"Bar": {"$ref": "#/components/schemas/Foo"}}}),
+        (
+            {"Foo": {"$ref": "#/definitions/Foo"}},
+            {"Foo": {"$ref": "#/components/schemas/Foo"}},
+        ),
+        (
+            {"Foo": {"Bar": {"$ref": "#/definitions/Foo"}}},
+            {"Foo": {"Bar": {"$ref": "#/components/schemas/Foo"}}},
+        ),
         (["foo", "bar"], ["foo", "bar"]),
-        (["foo", {"Foo": {"Bar": {"$ref": "#/definitions/Foo"}}}], ["foo", {"Foo": {"Bar": {"$ref": "#/components/schemas/Foo"}}}]),
-
-    ]
+        (
+            ["foo", {"Foo": {"Bar": {"$ref": "#/definitions/Foo"}}}],
+            ["foo", {"Foo": {"Bar": {"$ref": "#/components/schemas/Foo"}}}],
+        ),
+    ],
 )
 def test_nested_update_references(
-        input: Union[str, Dict[str, Any], List[str], List[Dict[str, Any]]],
-        output: Union[str, Dict[str, Any], List[str], List[Dict[str, Any]]]
+    input: Union[str, Dict[str, Any], List[str], List[Dict[str, Any]]],
+    output: Union[str, Dict[str, Any], List[str], List[Dict[str, Any]]],
 ) -> None:
     assert _nested_update_references(input) == output

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -216,7 +216,7 @@ def test_openapi_deprecated():
     api.register(app)
     spec = api.spec
 
-    assert spec["paths"]["/lone"]["post"]["deprecated"] == True
+    assert spec["paths"]["/lone"]["post"]["deprecated"] is True
     assert "deprecated" not in spec["paths"]["/lone"]["get"]
 
 

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -138,9 +138,7 @@ def create_app():
         pass
 
     @app.route("/multipart-file", methods=["POST"])
-    @api.validate(
-        body=MultipartFormRequest(ExampleModel), resp=Response(HTTP_200=ExampleModel)
-    )
+    @api.validate(body=MultipartFormRequest(ExampleModel), resp=Response(HTTP_200=ExampleModel))
     def post_multipart_form():
         pass
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -74,9 +74,7 @@ def test_has_model():
 
 def test_parse_resp():
     assert parse_resp(undecorated_func, 422) == {}
-    assert parse_resp(demo_class.demo_method, 422) == {
-        "422": {"description": "Validation Error"}
-    }
+    assert parse_resp(demo_class.demo_method, 422) == {"422": {"description": "Validation Error"}}
     resp_spec = parse_resp(demo_func, 422)
     assert resp_spec["422"]["description"] == "Validation Error"
     assert (


### PR DESCRIPTION
This PR removes a frequently failing to build dependency `nested-alter`, and replicates that behaviour in the library.
It's quite unpleasant how many places can have references, there may be a neater way to do this.