### PR TITLE
Simplify spec ref location mutation and update tests

### DIFF
--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -9,7 +9,6 @@ from pydantic import BaseModel, StrictFloat, Field
 
 from flask_pydantic_spec import Response
 from flask_pydantic_spec.flask_backend import FlaskBackend
-from flask_pydantic_spec.spec import _nested_update_references
 from flask_pydantic_spec.types import FileResponse, Request, MultipartFormRequest
 from flask_pydantic_spec import FlaskPydanticSpec
 from flask_pydantic_spec.config import Config
@@ -218,28 +217,9 @@ def test_openapi_deprecated():
     assert "deprecated" not in spec["paths"]["/lone"]["get"]
 
 
-@pytest.mark.parametrize(
-    "input,output",
-    [
-        ("a string", "a string"),
-        ({"$ref": "#/definitions/Foo"}, {"$ref": "#/components/schemas/Foo"}),
-        (
-            {"Foo": {"$ref": "#/definitions/Foo"}},
-            {"Foo": {"$ref": "#/components/schemas/Foo"}},
-        ),
-        (
-            {"Foo": {"Bar": {"$ref": "#/definitions/Foo"}}},
-            {"Foo": {"Bar": {"$ref": "#/components/schemas/Foo"}}},
-        ),
-        (["foo", "bar"], ["foo", "bar"]),
-        (
-            ["foo", {"Foo": {"Bar": {"$ref": "#/definitions/Foo"}}}],
-            ["foo", {"Foo": {"Bar": {"$ref": "#/components/schemas/Foo"}}}],
-        ),
-    ],
-)
-def test_nested_update_references(
-    input: Union[str, Dict[str, Any], List[str], List[Dict[str, Any]]],
-    output: Union[str, Dict[str, Any], List[str], List[Dict[str, Any]]],
-) -> None:
-    assert _nested_update_references(input) == output
+def test_flat_array_schemas():
+    app = create_app()
+    api.register(app)
+    spec = api.spec
+
+    assert spec["components"]["schemas"][ExampleNestedList.__name__].get("items") is not None


### PR DESCRIPTION
This PR drops the complicated `_nested_update_references` function and just uses pydantic functionality for setting the schema location as an OpenAPI compliant document.

It also fixes an issue where we dropped out the `items` from a top level array schema (fixes #47)