### PR TITLE
Bump setup and changes for new version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,11 @@
 .. currentmodule:: flask-pydantic-spec
+VERSION 0.4.3
+-------------
+
+Release 2023-03-13
+
+- Use Pydantic functionality to generate valid OpenAPI spec and fix issue with custom `__root__` models.
+
 VERSION 0.4.2
 -------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [tool.black]
 line-length = 100
-target-version = ['py38', 'py39', 'py310']
+target-version = ['py38', 'py39', 'py310', 'py311']
 
 [tool.mypy]
 ignore_missing_imports = true

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(here, "requirements/production.txt"), encoding="utf-8") as f
 
 setup(
     name="flask_pydantic_spec",
-    version="0.4.2",
+    version="0.4.3",
     author="Chris Gearing, Simon Hayward, Rob Young, Donald Fleming, Saurabh Jha",
     author_email="chris.gearing@turntown.digital",
     description=(


### PR DESCRIPTION
This PR bumps the version for 0.4.3, and also adds 3.11 compatibility to our black formatting