### PR TITLE
Check for definitions in schema before deleting

### DIFF
--- a/flask_pydantic_spec/spec.py
+++ b/flask_pydantic_spec/spec.py
@@ -315,7 +315,8 @@ class FlaskPydanticSpec:
                 for key, value in schema["definitions"].items():
                     definitions[key] = self._get_open_api_schema(value)
                 del schema["definitions"]
-                del definitions[model]["definitions"]
+                if "definitions" in definitions[model]:
+                    del definitions[model]["definitions"]
 
         return definitions
 


### PR DESCRIPTION
On some models this key may not be present.