### PR TITLE
Fix exception being thrown when JSON header is present but body is empty

### DIFF
--- a/flask_pydantic_spec/flask_backend.py
+++ b/flask_pydantic_spec/flask_backend.py
@@ -142,7 +142,7 @@ class FlaskBackend:
                 raw_body = gzip.decompress(request.stream.read()).decode(encoding="utf-8")
                 parsed_body = json.loads(raw_body)
             else:
-                parsed_body = request.get_json() or {}
+                parsed_body = request.get_json(silent=True) or {}
         elif request.content_type and "multipart/form-data" in request.content_type:
             parsed_body = parse_multi_dict(request.form) if request.form else {}
         else:

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -121,6 +121,11 @@ def test_flask_validate(client):
     assert resp.headers.get("X-Error") is None
     assert resp.headers.get("X-Validation") == "Pass"
 
+    resp = client.get("/ping", headers={"lang": "en-US", "Content-Type": "application/json"})
+    assert resp.json == {"msg": "pong"}
+    assert resp.headers.get("X-Error") is None
+    assert resp.headers.get("X-Validation") == "Pass"
+
     resp = client.post("api/user/flask")
     assert resp.status_code == 422
     assert resp.headers.get("X-Error") == "Validation Error"


### PR DESCRIPTION
There's a small edge case where, if the `"Content-Type: application/json"` header is present and the body is empty (e.g. some GET request with leftover headers), `request_validation` will throw an exception.

I believe this is not expected behavior as this does not happen in other clients and libraries AFAIK.

Along with the changes I added some tests to check this edge case. I believe they are in the right place, but to be honest I had a hard time understanding how the tests were organized.