### PR TITLE
Add support for custom URL converters

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -69,9 +69,11 @@ class FileName(BaseModel):
     file_name: str
     data: FileMetadata
 
+
 class ExampleEnum(Enum):
     one = "one"
     two = "two"
+
 
 class ExampleConverter(BaseConverter):
     def to_python(self, value) -> ExampleEnum:

--- a/tests/common.py
+++ b/tests/common.py
@@ -3,6 +3,7 @@ from enum import IntEnum, Enum
 from typing import List, Optional
 
 from pydantic import BaseModel, root_validator
+from werkzeug.routing import BaseConverter
 
 
 class Order(IntEnum):
@@ -67,6 +68,25 @@ class FileMetadata(BaseModel):
 class FileName(BaseModel):
     file_name: str
     data: FileMetadata
+
+class ExampleEnum(Enum):
+    one = "one"
+    two = "two"
+
+class ExampleConverter(BaseConverter):
+    def to_python(self, value) -> ExampleEnum:
+        return ExampleEnum(value)
+
+    def to_url(self, value) -> str:
+        return value.value
+
+
+class UnknownConverter(BaseConverter):
+    def to_python(self, value) -> object:
+        return object()
+
+    def to_url(self, value) -> str:
+        return str(value)
 
 
 def get_paths(spec):


### PR DESCRIPTION
This change adds support for custom URL converters so long as they return an Enum. It also includes a bit of an overhaul of the path parsing code as it had a few mistakes.

## New feature
If a custom URL converter has a type annotation on it's `to_python` method and that method returns an Enum then generate an appropriate schema for it. Otherwise fall back to a default string schema. This results in there always being a schema otherwise the generated OpenAPI spec is not valid.

## Fixes
The ["any" converter](https://werkzeug.palletsprojects.com/en/2.3.x/routing/#werkzeug.routing.AnyConverter) does not expect an array of enums. It expects *one* of the given items.

The ["string" converter](https://werkzeug.palletsprojects.com/en/2.3.x/routing/#werkzeug.routing.UnicodeConverter) expects the argument keys to be lowercase.

Having a null schema is not valid according to the OpenAPI spec. This change falls back to a default string schema as ultimately the path is a string.