### PR TITLE
[Chore] - Remove support for Python 3.7

### DIFF
--- a/.github/workflows/test-static-analysis.yml
+++ b/.github/workflows/test-static-analysis.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
         os: [ubuntu-latest]
 
     steps:

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
     package_data={},
     classifiers=[
         "Programming Language :: Python :: 3 :: Only",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -36,7 +35,7 @@ setup(
         "Operating System :: OS Independent",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=requires,
     extras_require={
         "flask": ["flask"],

--- a/tests/test_plugin_flask.py
+++ b/tests/test_plugin_flask.py
@@ -130,7 +130,7 @@ def test_flask_validate(client):
     assert resp.status_code == 422
     assert resp.headers.get("X-Error") == "Validation Error"
 
-    client.set_cookie("flask", "pub", "abcdefg")
+    client.set_cookie("pub", "abcdefg")
     resp = client.post(
         "/api/user/flask?order=1",
         data=json.dumps(dict(name="flask", limit=10)),
@@ -226,7 +226,7 @@ def test_flask_post_gzip(client):
     body = dict(name="flask", limit=10)
     compressed = gzip.compress(bytes(json.dumps(body), encoding="utf-8"))
 
-    client.set_cookie("flask", "pub", "abcdefg")
+    client.set_cookie("pub", "abcdefg")
     resp = client.post(
         "/api/user/flask?order=0",
         data=compressed,
@@ -244,7 +244,7 @@ def test_flask_post_gzip_failure(client):
     body = dict(name="flask")
     compressed = gzip.compress(bytes(json.dumps(body), encoding="utf-8"))
 
-    client.set_cookie("flask", "pub", "abcdefg")
+    client.set_cookie("pub", "abcdefg")
     resp = client.post(
         "/api/user/flask?order=0",
         data=compressed,


### PR DESCRIPTION
Python 3.7 is end of life and we are now seeing test failures for dependencies that no longer support 3.7. 

This PR removes 3.7 as a supported version of Python moving forward.

It also fixes a test failure where Werkzeug has changed the arguments for setting a cookie.