### PR TITLE
bug: fix typo for Status Code 507

### DIFF
--- a/flask_pydantic_spec/types.py
+++ b/flask_pydantic_spec/types.py
@@ -306,7 +306,7 @@ DEFAULT_CODE_DESC = {
     "HTTP_504": "Gateway Timeout",
     "HTTP_505": "HTTP Version Not Supported",
     "HTTP_506": "Variant Also negotiates",
-    "HTTP_507": "Insufficient Sotrage",
+    "HTTP_507": "Insufficient Storage",
     "HTTP_508": "Loop Detected",
     "HTTP_511": "Network Authentication Required",
 }


### PR DESCRIPTION
Just fixing a typo on the HTTP Status Code 507 from types.py