### PR TITLE
Fix: Swagger UI does not support OpenApi 3.1.0

### DIFF
--- a/flask_pydantic_spec/page.py
+++ b/flask_pydantic_spec/page.py
@@ -36,7 +36,7 @@ PAGES = {
         <meta charset="UTF-8">
         <title>{0.TITLE}</title>
         <link rel="stylesheet" type="text/css"
-        href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@3/swagger-ui.css" >
+        href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css" >
         <style>
         html
         {{
@@ -64,9 +64,9 @@ PAGES = {
         <div id="swagger-ui"></div>
 
         <script
-src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@3/swagger-ui-bundle.js"></script>
+src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
         <script
-src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@3/swagger-ui-standalone-preset.js"></script>
+src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-standalone-preset.js"></script>
         <script>
         window.onload = function() {{
         // Begin Swagger UI call region


### PR DESCRIPTION
Upgrade swagger ui to v5, to add OpenAPI v3.1.0 support. See support table in swagger-ui: https://github.com/swagger-api/swagger-ui?tab=readme-ov-file#compatibility