### PR TITLE
Add support for V1 models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [tool.black]
 line-length = 100
-target-version = ['py38', 'py39', 'py310', 'py311']
+target-version = ['py39', 'py310', 'py311', 'py312', 'py313']
 
 [tool.mypy]
 ignore_missing_imports = true
@@ -15,9 +15,7 @@ no_implicit_optional = true
 warn_redundant_casts = true
 warn_unused_ignores = true
 warn_return_any = true
-plugins = [
-  "pydantic.mypy"
-]
+plugins = ["pydantic.mypy"]
 
 [tool.pydantic-mypy]
 init_forbid_extra = true

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,6 +1,6 @@
 -r production.txt
 openapi-spec-validator == 0.7.1
-pytest>=6.0.1, <7
+pytest>=8.3.5, <9
 flake8 == 7.1.1
 flask>=2.0.2, <3
 requests>=2.24.0, <3

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ exclude =
     old,
     build,
     dist,
-    venv
+    venv,
+    .venv
 max-line-length = 100
 max-complexity = 15
-

--- a/tests/common.py
+++ b/tests/common.py
@@ -2,7 +2,7 @@ from datetime import date
 from enum import IntEnum, Enum
 from typing import List, Optional
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, model_validator, v1
 from werkzeug.routing import BaseConverter
 
 
@@ -89,6 +89,60 @@ class UnknownConverter(BaseConverter):
 
     def to_url(self, value) -> str:
         return str(value)
+
+
+class QueryV1(v1.BaseModel):
+    order: Optional[Order] = None
+
+
+class QueryParamsV1(v1.BaseModel):
+    name: Optional[List[str]] = None
+
+
+class UserV1(v1.BaseModel):
+    name: str
+
+
+class UsersV1(v1.BaseModel):
+    data: List[UserV1]
+
+
+class JSONV1(v1.BaseModel):
+    name: str
+    limit: int
+
+
+class RespV1(v1.BaseModel):
+    name: str
+    score: List[int]
+
+
+class HeadersV1(v1.BaseModel):
+    lang: Language
+
+    @v1.root_validator(pre=True)
+    def lower_keys(cls, values):
+        return {key.lower(): value for key, value in values.items()}
+
+
+class CookiesV1(v1.BaseModel):
+    pub: str
+
+
+class DemoModelV1(v1.BaseModel):
+    uid: int
+    limit: int
+    name: str
+
+
+class FileMetadataV1(v1.BaseModel):
+    type: str
+    created_at: date
+
+
+class FileNameV1(v1.BaseModel):
+    file_name: str
+    data: FileMetadataV1
 
 
 def get_paths(spec):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -12,6 +12,11 @@ def test_plugin_spec():
         "/api/user",
         "/api/user/{name}",
         "/ping",
+        "/v1/api/file",
+        "/v1/api/group/{name}",
+        "/v1/api/user",
+        "/v1/api/user/{name}",
+        "/v1/ping",
     ]
 
     ping = api.spec["paths"]["/ping"]["get"]


### PR DESCRIPTION
Pydantic V2 still exposes the V1 model API. This change allows both V1 and V2 models to be used interchangeably.

This change breaks backwards compatibility in typing because certain public APIs now may accept either a v1 or a v2 model where previously only a v2 model would be provided.
