### PR TITLE
fix: bug with unwrapped v1 models as body

### DIFF
--- a/flask_pydantic_spec/spec.py
+++ b/flask_pydantic_spec/spec.py
@@ -4,7 +4,6 @@ from functools import wraps
 from typing import Mapping, Optional, Type, Union, Callable, Iterable, Any, Dict
 
 from flask import Flask, Response as FlaskResponse
-from pydantic import BaseModel, v1
 from inflection import camelize
 
 from . import Request
@@ -87,7 +86,8 @@ class FlaskPydanticSpec:
     def bypass(self, func: Callable) -> bool:
         """Bypass routes not decorated by FlaskPydanticSpec
 
-        In OpenAPI 3.1, it's not valid to have a route that doesn't have at least one response attached
+        In OpenAPI 3.1, it's not valid to have a route that doesn't have at least one
+        response attached.
         """
         decorator = getattr(func, "_decorator", None)
         if decorator and decorator != self:

--- a/flask_pydantic_spec/utils.py
+++ b/flask_pydantic_spec/utils.py
@@ -81,7 +81,7 @@ def parse_request(func: Callable) -> Mapping[str, Any]:
         request_body = getattr(func, "body")
         if isinstance(request_body, RequestBase):
             result: Mapping[str, Any] = request_body.generate_spec()
-        elif issubclass(request_body, BaseModel):
+        elif issubclass(request_body, (BaseModel, v1.BaseModel)):
             result = Request(request_body).generate_spec()
         else:
             result = {}

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -187,7 +187,7 @@ def app(api: FlaskPydanticSpec) -> Flask:
 
     @app.post("/v1/lone")
     @api.validate(
-        body=Request(ExampleV1Model),
+        body=ExampleV1Model,
         resp=Response(HTTP_200=ExampleV1NestedList, HTTP_400=ExampleV1NestedModel),
         tags=["lone"],
         deprecated=True,
@@ -395,4 +395,15 @@ def test_v1_routes_with_nullable_match(app: Flask, api: FlaskPydanticSpec, route
     assert v2_query_type == {
         "anyOf": [{"$ref": "#/components/schemas/TypeEnum"}, {"type": "null"}],
         "default": None,
+    }
+
+
+def test_v1_route_request_bodies(app: Flask, api: FlaskPydanticSpec):
+    api.register(app)
+    spec = api.spec
+
+    v1_spec = spec["paths"]["/v1/lone"]["post"]
+
+    assert v1_spec["requestBody"] == {
+        "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ExampleV1Model"}}}
     }


### PR DESCRIPTION
fix: bug with unwrapped v1 models as body

One check for `BaseModel` was not updated to also include `v1.BaseModel`
meaning that body's were missed for unwrapped v1 body models.

Also includes some minor style fixes.

