### PR TITLE
Support stacked routes

### DIFF
--- a/flask_pydantic_spec/spec.py
+++ b/flask_pydantic_spec/spec.py
@@ -16,7 +16,6 @@ from .utils import (
     parse_request,
     parse_params,
     parse_resp,
-    parse_name,
     default_before_handler,
     default_after_handler,
     get_model_name,
@@ -191,7 +190,7 @@ class FlaskPydanticSpec:
                 if self.backend.bypass(func, method) or self.bypass(func):
                     continue
 
-                name = parse_name(func)
+                name = route.endpoint
                 summary, desc = parse_comments(func)
                 func_tags = getattr(func, "tags", ())
                 for tag in func_tags:

--- a/flask_pydantic_spec/utils.py
+++ b/flask_pydantic_spec/utils.py
@@ -180,17 +180,6 @@ def has_model(func: Callable) -> bool:
     return False
 
 
-def parse_name(func: Callable) -> str:
-    """
-    the func can be
-
-        * undecorated functions
-        * decorated functions
-        * decorated class methods
-    """
-    return func.__name__
-
-
 def default_before_handler(
     req: Request, resp: Response, req_validation_error: Any, instance: BaseModel
 ) -> None:

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -223,6 +223,12 @@ def app(api: FlaskPydanticSpec) -> Flask:
     def should_bypass():
         pass
 
+    @app.get("/v1/stacked", endpoint="get_v1_stacked")
+    @app.get("/v2/stacked", endpoint="get_v2_stacked")
+    @api.validate(resp=Response(HTTP_200=None))
+    def get_stacked():
+        pass
+
     return app
 
 
@@ -425,3 +431,11 @@ def test_v1_nested_model_definitions(spec: Mapping[str, Any]):
 
 def test_undecorated_routes_should_be_skipped(spec: Mapping[str, Any]):
     assert "/should-bypass" not in spec["paths"]
+
+
+def test_stacked(spec: Mapping[str, Any]):
+    v1 = spec["paths"]["/v1/stacked"]
+    v2 = spec["paths"]["/v2/stacked"]
+
+    assert v1["get"]["operationId"] == "getV1Stacked"
+    assert v2["get"]["operationId"] == "getV2Stacked"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,6 @@ from flask_pydantic_spec.utils import (
     parse_params,
     parse_resp,
     has_model,
-    parse_name,
 )
 from flask_pydantic_spec.spec import FlaskPydanticSpec
 from flask_pydantic_spec.types import Response, Request, _parse_code
@@ -57,13 +56,6 @@ def test_parse_code():
 
     assert _parse_code("200") is None
     assert _parse_code("HTTP_404") == "404"
-
-
-def test_parse_name():
-    assert parse_name(lambda x: x) == "<lambda>"
-    assert parse_name(undecorated_func) == "undecorated_func"
-    assert parse_name(demo_func) == "demo_func"
-    assert parse_name(demo_class.demo_method) == "demo_method"
 
 
 def test_has_model():


### PR DESCRIPTION
A route function can be decorated more than once in flask. Currently this results in two OpenAPI operations with the same ID which is not valid. This change uses the route's `endpoint` which defaults to the name of the wrapped function.

See: https://flask.palletsprojects.com/en/stable/api/#flask.Flask.add_url_rule

## Example

Before this change:

```python
@app.get("/v1/foo", endpoint="v1_foo")
@app.get("/v2/foo", endpoint="v2_foo")
@spec.validate(resp=Response(HTTP_200=None))
def get_foo():
  ...
```

Would result two routes with `GET` operations with `operationId` of `get_foo`.

After this change each operation would get the value of `endpoint`.
