### PR TITLE
Ensure tags are sorted in the OpenAPI spec

### DIFF
--- a/flask_pydantic_spec/spec.py
+++ b/flask_pydantic_spec/spec.py
@@ -225,7 +225,7 @@ class FlaskPydanticSpec:
                     "version": self.config.VERSION,
                 },
             },
-            "tags": list(tags.values()),
+            "tags": sorted(tags.values(), key=lambda t: t["name"]),
             "paths": {**routes},
             "components": {"schemas": {**self._get_model_definitions()}},
         }

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4,7 +4,7 @@ from .test_plugin_flask import api as flask_api
 
 def test_plugin_spec():
     api = flask_api
-    assert api.spec["tags"] == [{"name": tag} for tag in ("test", "health", "api")]
+    assert api.spec["tags"] == [{"name": tag} for tag in ("api", "health", "test")]
 
     assert get_paths(api.spec) == [
         "/api/file",

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -153,7 +153,11 @@ def app(api: FlaskPydanticSpec) -> Flask:
         pass
 
     @app.get("/query")
-    @api.validate(query=ExampleQuery, resp=Response(HTTP_200=List[ExampleModel]))
+    @api.validate(
+        query=ExampleQuery,
+        resp=Response(HTTP_200=List[ExampleModel]),
+        tags=["alpha"],
+    )
     def get_query():
         pass
 
@@ -205,7 +209,9 @@ def app(api: FlaskPydanticSpec) -> Flask:
         pass
 
     @app.get("/v1/query")
-    @api.validate(query=ExampleV1Query, resp=Response(HTTP_200=List[ExampleV1Model]))
+    @api.validate(
+        query=ExampleV1Query, resp=Response(HTTP_200=List[ExampleV1Model]), tags=["alpha"]
+    )
     def get_query_v1():
         pass
 
@@ -258,8 +264,10 @@ def test_openapi_tags(app: Flask, api: FlaskPydanticSpec):
     api.register(app)
     spec = api.spec
 
-    assert spec["tags"][0]["name"] == "lone"
-    assert spec["tags"][0]["description"] == "a lone api"
+    assert spec["tags"] == [
+        {"name": "alpha"},
+        {"name": "lone", "description": "a lone api"},
+    ]
 
 
 def test_openapi_deprecated(app: Flask, api: FlaskPydanticSpec):


### PR DESCRIPTION
Ensure tags are sorted in the OpenAPI spec

This has an impact on the order routes are shown in web renders of the
spec.

