### PR TITLE
Allow operationId to be customized

### DIFF
--- a/flask_pydantic_spec/spec.py
+++ b/flask_pydantic_spec/spec.py
@@ -35,7 +35,7 @@ class FlaskPydanticSpec:
     :param str backend_name: choose from ('flask')
     :param backend: a backend that inherit `flask_pydantic_spec.FlaskBackend`
     :param app: backend framework application instance (you can also register to it later)
-    :param before: a callback function of the form :meth:`fla.utils.default_before_handler`
+    :param before: a callback function of the form :meth:`flask.utils.default_before_handler`
         ``func(req, resp, req_validation_error, instance)``
         that will be called after the request validation before the endpoint function
     :param after: a callback function of the form :meth:`spectree.utils.default_after_handler`
@@ -190,7 +190,7 @@ class FlaskPydanticSpec:
                 if self.backend.bypass(func, method) or self.bypass(func):
                     continue
 
-                name = route.endpoint
+                operation_id = self.backend.get_operation_id(route, method, func)
                 summary, desc = parse_comments(func)
                 func_tags = getattr(func, "tags", ())
                 for tag in func_tags:
@@ -198,8 +198,8 @@ class FlaskPydanticSpec:
                         tags[tag] = tag_lookup.get(tag, {"name": tag})
 
                 routes[path][method.lower()] = {
-                    "summary": summary or f"{name} <{method}>",
-                    "operationId": camelize(f"{name}", False),
+                    "summary": summary or f"{operation_id} <{method}>",
+                    "operationId": camelize(f"{operation_id}", False),
                     "description": desc or "",
                     "tags": getattr(func, "tags", []),
                     "parameters": parse_params(func, parameters[:], self.models),

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1,14 +1,16 @@
 from enum import Enum
 import re
-from typing import Any, Mapping, Optional, List
+from typing import Any, Callable, Mapping, Optional, List
 
 import pytest
 from flask import Flask
 from openapi_spec_validator import OpenAPIV31SpecValidator
 from pydantic import BaseModel, StrictFloat, Field, RootModel
 from pydantic import v1
+from werkzeug.routing import Rule
 
 from flask_pydantic_spec import Response
+from flask_pydantic_spec.flask_backend import FlaskBackend
 from flask_pydantic_spec.types import FileResponse, Request, MultipartFormRequest
 from flask_pydantic_spec import FlaskPydanticSpec
 from flask_pydantic_spec.config import Config
@@ -84,12 +86,18 @@ def name():
     return "flask"
 
 
+class FlaskBackendUsingEndpoint(FlaskBackend):
+    def get_operation_id(self, route: Rule, method: str, func: Callable) -> str:
+        return route.endpoint
+
+
 @pytest.fixture
 def api(name) -> FlaskPydanticSpec:
     return FlaskPydanticSpec(
         name,
         tags=[{"name": "lone", "description": "a lone api"}],
         validation_error_code=400,
+        backend=FlaskBackendUsingEndpoint,
     )
 
 


### PR DESCRIPTION
Allow operationId to be customized

This effectively reverts #87 as it had unintended consequences
when used with blueprints. The endpoint for a blueprint by default
is `app_name.blueprint_name.function_name`. This means that #83
would result in significant changes to existing OpenAPI specs.
This change instead keeps the operationId the same by default but
offers a route to overriding it.

The `get_operation_id` method can be overriden in a custom backend.

```python
class MyCustomBackend(FlaskBackend):
    def get_operation_id(self, route, method, func):
        return route.endpoint.split(".")[-1]

api = FlaskPydanticSpec(
    "my_spec",
    backend=MyCustomBackend,
)
```