### PR TITLE
(feat) Add support for OpenAPI extensions

### DIFF
--- a/flask_pydantic_spec/spec.py
+++ b/flask_pydantic_spec/spec.py
@@ -104,6 +104,7 @@ class FlaskPydanticSpec:
         deprecated: bool = False,
         before: Optional[Callable] = None,
         after: Optional[Callable] = None,
+        extensions: Optional[Dict[str, Any]] = None,
     ) -> Callable:
         """
         - validate query, body, headers in request
@@ -120,6 +121,7 @@ class FlaskPydanticSpec:
                     should be transitioned out of usage
         :param before: :meth:`spectree.utils.default_before_handler` for specific endpoint
         :param after: :meth:`spectree.utils.default_after_handler` for specific endpoint
+        :param extensions: a key value map of extension strings
         """
 
         def decorate_validation(func: Callable) -> Callable:
@@ -167,6 +169,12 @@ class FlaskPydanticSpec:
             if deprecated:
                 setattr(validation, "deprecated", True)
 
+            if extensions:
+                for key, value in extensions.items():
+                    if not key or not key.startswith('x'):
+                        raise ValueError("Swagger vendor extensions must begin with 'x-'")
+                setattr(validation, "extensions", extensions)
+
             # register decorator
             setattr(validation, "_decorator", self)
             return validation
@@ -207,6 +215,10 @@ class FlaskPydanticSpec:
                 }
                 if hasattr(func, "deprecated"):
                     routes[path][method.lower()]["deprecated"] = True
+
+                extensions = getattr(func, "extensions", {})
+                if extensions:
+                    routes[path][method.lower()].update(**extensions)
 
                 request_body = parse_request(func)
                 if request_body:

--- a/flask_pydantic_spec/spec.py
+++ b/flask_pydantic_spec/spec.py
@@ -171,7 +171,7 @@ class FlaskPydanticSpec:
 
             if extensions:
                 for key, value in extensions.items():
-                    if not key or not key.startswith('x'):
+                    if not key or not key.startswith('x-'):
                         raise ValueError("Swagger vendor extensions must begin with 'x-'")
                 setattr(validation, "extensions", extensions)
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open(path.join(here, "requirements/production.txt"), encoding="utf-8") as f
 
 setup(
     name="flask_pydantic_spec",
-    version="0.8.4",
+    version="0.8.5",
     author="Chris Gearing, Simon Hayward, Rob Young, Donald Fleming",
     author_email="chris.gearing@turntown.digital",
     description=(

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1,6 +1,6 @@
 from enum import Enum
 import re
-from typing import Any, Callable, Mapping, Optional, List
+from typing import Any, Callable, Dict, Mapping, Optional, List
 
 import pytest
 from flask import Flask
@@ -233,6 +233,11 @@ def app(api: FlaskPydanticSpec) -> Flask:
     def get_enum_v1(example):
         pass
 
+    @app.get("/extensions")
+    @api.validate(resp=Response(HTTP_200=ExampleModel), extensions={"x-key": "value"})
+    def extensions():
+        pass
+
     @app.get("/should-bypass")
     def should_bypass():
         pass
@@ -276,6 +281,33 @@ def test_openapi_tags(app: Flask, api: FlaskPydanticSpec):
         {"name": "alpha"},
         {"name": "lone", "description": "a lone api"},
     ]
+
+
+def test_openapi_extensions(app: Flask, api: FlaskPydanticSpec):
+    api.register(app)
+    spec = api.spec
+
+    assert {"x-key": "value"}.items() <= spec["paths"]["/extensions"]["get"].items()
+
+
+@pytest.mark.parametrize(
+    ["extensions"],
+    [
+        [{"": "value"}],
+        [{"key": "value"}]
+    ],
+    ids=[
+        "empty key",
+        "key doesn't start with x",
+    ]
+)
+def test_openapi_extensions__fails(extensions: Dict, app: Flask, api: FlaskPydanticSpec):
+    with pytest.raises(ValueError) as exc_info:
+        @api.validate(resp=Response(HTTP_200=None), extensions=extensions)
+        def get_with_invalid_extension():
+            pass
+
+    assert "Swagger vendor extensions must begin with 'x-'" in str(exc_info)
 
 
 def test_openapi_deprecated(app: Flask, api: FlaskPydanticSpec):


### PR DESCRIPTION
This PR adds support for OpenAPI [Vendor Extensions](https://swagger.io/docs/specification/v3_0/openapi-extensions/).

```python
@app.get("/")
@api.validate(
    resp=Response(HTTP_200=ExampleModel),
    extensions={"x-rate-limit-tier": "premium"},
)
def my_endpoint():
    ...
```



