### PR TITLE
Ensure path and schema order is consistent

### DIFF
--- a/flask_pydantic_spec/spec.py
+++ b/flask_pydantic_spec/spec.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from copy import deepcopy
 from functools import wraps
 from typing import Mapping, Optional, Type, Union, Callable, Iterable, Any, Dict
+from operator import itemgetter
 
 from flask import Flask, Response as FlaskResponse, Blueprint, jsonify
 from flask.blueprints import BlueprintSetupState
@@ -284,8 +285,10 @@ class FlaskPydanticSpec:
                 },
             },
             "tags": sorted(tags.values(), key=lambda t: t["name"]),
-            "paths": {**routes},
-            "components": {"schemas": {**self._get_model_definitions()}},
+            "paths": dict(sorted(routes.items(), key=itemgetter(0))),
+            "components": {
+                "schemas": dict(sorted(self._get_model_definitions().items(), key=itemgetter(0)))
+            },
         }
         return spec
 

--- a/tests/spec/test_app.py
+++ b/tests/spec/test_app.py
@@ -481,3 +481,13 @@ def test_stacked(spec: Mapping[str, Any]):
 
     assert v1["get"]["operationId"] == "getV1Stacked"
     assert v2["get"]["operationId"] == "getV2Stacked"
+
+
+def test_paths_sorted(spec: Mapping[str, Any]):
+    assert list(spec["paths"].keys()) == sorted(spec["paths"].keys())
+
+
+def test_schemas_sorted(spec: Mapping[str, Any]):
+    assert list(spec["components"]["schemas"].keys()) == sorted(
+        spec["components"]["schemas"].keys()
+    )


### PR DESCRIPTION
Ensure path and schema order is consistent

Changing where a path or schema first appears can change their order in
the OpenAPI spec which makes diffing changes more difficult. This change
ensures they are always sorted by key.

